### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/Relativity/security/code-scanning/1](https://github.com/lookbusy1344/Relativity/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block at the root (workflow) level rather than at the individual job level, since the workflow jobs only need minimal permission. The minimal permission required for checking out repository contents is `contents: read`. Adding `permissions: contents: read` near the top of the file (just after the `name:` and before `on:` is the canonical best practice in this case, applying to all jobs in the workflow. No other code or job steps are affected, and this does not change existing workflow functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
